### PR TITLE
Add required limits property to campaign creation in test.

### DIFF
--- a/test/test_integration_api_live.rb
+++ b/test/test_integration_api_live.rb
@@ -6,7 +6,7 @@ class TestIntegrationApiLive < LiveApiTest
       currency: "USD",
       timezone: "UTC"
     )
-    @campaign = management_client.post "/v1/applications/#{@app["id"]}/campaigns", { name: "Test Campaign", state: 'disabled', tags: [] }
+    @campaign = management_client.post "/v1/applications/#{@app["id"]}/campaigns", { name: "Test Campaign", state: 'disabled', tags: [], limits: [] }
     @ruleset = management_client.post "/v1/applications/#{@app["id"]}/campaigns/#{@campaign["id"]}/rulesets", rules: [{
       title: "Free money for all!",
       condition: ["and", true],


### PR DESCRIPTION
Fix the test that's failing because of the required limits missing.