### PR TITLE
Improve error handling for timeout errors

### DIFF
--- a/lib/talon_one/api_client.rb
+++ b/lib/talon_one/api_client.rb
@@ -55,7 +55,8 @@ module TalonOne
 
       unless response.success?
         if response.timed_out?
-          fail ApiError.new('Connection timed out')
+          fail ApiError.new(:message => 'Connection timed out',
+                            timeout: true)
         elsif response.code == 0
           # Errors from libcurl will be made visible here
           fail ApiError.new(:code => 0,

--- a/lib/talon_one/api_error.rb
+++ b/lib/talon_one/api_error.rb
@@ -12,7 +12,7 @@ OpenAPI Generator version: 4.3.1
 
 module TalonOne
   class ApiError < StandardError
-    attr_reader :code, :response_headers, :response_body
+    attr_reader :code, :response_headers, :response_body, :timeout
 
     # Usage examples:
     #   ApiError.new


### PR DESCRIPTION
This PR improves the error handling for timeout errors. There are effectively three classes of error that the Talon client can raise:
* A request times out from Typhoeus. This generally only occurs if the client has specified a timeout.
* A request fails with an error from `libcurl`. This can occur for a host of reasons, but it is difficult to get more precise information out of `libcurl`.
* A request fails with an HTTP error. In this case, we can pull detailed response information into the error object.

With this PR, it is now possible for clients to differentiate these cases and handle them differently:
* In a timeout, `code` will be `nil` and `timeout` will be true.
* In a libcurl failure, `code` will specifically be 0.
* In an HTTP failure, the code will be something meaningful.

This isn't perfect, but it does improve the error handling ability for clients somewhat!